### PR TITLE
Fix missing input requirement

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ N_NEIGHBORS = 5
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='argument parser')
-    parser.add_argument('--input', help='Input file path')
+    parser.add_argument('--input', required=True, help='Input file path')
 
     # Parse the command-line arguments
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- require `--input` argument for main execution

## Testing
- `python -m py_compile main.py src/img2vec_resnet18.py`


------
https://chatgpt.com/codex/tasks/task_e_6844466d31d88324af207eec3cec28fd