### PR TITLE
Configure axios base URL

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+
+// Point axios at the FastAPI backend running on port 8000
+axios.defaults.baseURL = 'http://localhost:8000';
 import { log } from './logger';
 
 


### PR DESCRIPTION
## Summary
- set axios default base URL so API requests go to FastAPI backend

## Testing
- `npm --version`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844658189c88324ab25a3f2977defbc