### PR TITLE
Improve clustering flow and results UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,9 +4,10 @@ import base64
 import os
 import io
 from typing import Dict, List
+from PIL import Image
 import logging
 
-from fastapi import FastAPI, UploadFile, File, Depends
+from fastapi import FastAPI, UploadFile, File, Depends, Query
 from sqlalchemy import Column, Integer, String, DateTime, create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base, Session
 
@@ -52,8 +53,11 @@ async def log_message(message: Dict[str, str]):
     return {"status": "logged"}
 
 @app.post("/upload-image")
-async def upload_image(file: UploadFile = File(...)):
-    logger.info("Received upload: %s", file.filename)
+async def upload_image(
+    file: UploadFile = File(...),
+    clusters: int = Query(10, description="Number of clusters")
+):
+    logger.info("Received upload: %s with %d clusters", file.filename, clusters)
 
     with NamedTemporaryFile(delete=False, suffix=os.path.splitext(file.filename)[1]) as tmp:
         content = await file.read()
@@ -64,19 +68,40 @@ async def upload_image(file: UploadFile = File(...)):
         detections = detector.detect_products(tmp_path)
         os.remove(tmp_path)
         logger.debug("Detections: %s", len(detections))
-        clusters = clusterer.cluster(detections)
-        logger.debug("Clusters formed: %s", len(clusters))
-        response: List[Dict] = []
-        for cluster_id, items in clusters.items():
+        clustered = clusterer.cluster(detections, n_clusters=clusters)
+        logger.debug("Clusters formed: %s", len(clustered))
+
+        with open(tmp_path, "rb") as f:
+            original_bytes = f.read()
+        original_image = Image.open(io.BytesIO(original_bytes))
+        width, height = original_image.size
+        original_encoded = base64.b64encode(original_bytes).decode("utf-8")
+        original_image.close()
+
+        response_clusters: List[Dict] = []
+        detection_data: List[Dict] = []
+        for cid, info in clustered.items():
+            items = info["items"]
+            rep_idx = info["representative_index"]
+
+            rep_buf = io.BytesIO()
+            items[rep_idx]["image"].save(rep_buf, format="JPEG")
+            rep_encoded = base64.b64encode(rep_buf.getvalue()).decode("utf-8")
+            response_clusters.append({"cluster_id": cid, "image": rep_encoded})
+
             for item in items:
-                buf = io.BytesIO()
-                item['image'].save(buf, format='JPEG')
-                encoded = base64.b64encode(buf.getvalue()).decode('utf-8')
-                response.append({
-                    'cluster_id': cluster_id,
-                    'image': encoded
+                detection_data.append({
+                    "cluster_id": cid,
+                    "bbox": item["bbox"],
                 })
-        return {'products': response}
+
+        return {
+            "image": original_encoded,
+            "width": width,
+            "height": height,
+            "clusters": response_clusters,
+            "detections": detection_data,
+        }
     except Exception as exc:
         logger.exception("Error processing image: %s", exc)
         return {'error': 'processing failed'}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+axios.defaults.baseURL = 'http://localhost:8000';
 import { log } from './logger';
 
 const masterData = [
@@ -8,68 +9,205 @@ const masterData = [
   'Fanta Bottle',
 ];
 
-function App() {
-  const [file, setFile] = useState(null);
-  const [products, setProducts] = useState([]);
-  const [labels, setLabels] = useState({});
+const colors = [
+  '#e6194b', '#3cb44b', '#ffe119', '#4363d8', '#f58231',
+  '#911eb4', '#42d4f4', '#f032e6', '#bfef45', '#fabebe',
+];
 
-  const handleUpload = async () => {
-    if (!file) return;
-    log('Uploading image');
-    const formData = new FormData();
-    formData.append('file', file);
-    try {
-      const res = await axios.post('/upload-image', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
-      log(`Received ${res.data.products.length} products`);
-      setProducts(res.data.products);
-    } catch (err) {
-      log(`Upload failed: ${err}`);
+function BoxOverlay({ image, detections, width, height, colorMap }) {
+  const [dims, setDims] = useState({ w: 1, h: 1 });
+  const imgRef = React.useRef(null);
+  useEffect(() => {
+    if (imgRef.current) {
+      setDims({ w: imgRef.current.width, h: imgRef.current.height });
     }
-  };
-
-  const handleChange = (clusterId, value) => {
-    setLabels(prev => ({ ...prev, [clusterId]: value }));
-  };
-
-  const handleSubmit = async () => {
-    log('Saving labels');
-    try {
-      await axios.post('/save-labels', labels);
-      alert('Labels saved');
-    } catch (err) {
-      log(`Save failed: ${err}`);
-    }
-  };
-
+  }, [image]);
+  const scale = (val, max, disp) => (val / max) * disp;
   return (
-    <div className="p-4">
-      <input type="file" onChange={e => setFile(e.target.files[0])} />
-      <button onClick={handleUpload}>Upload</button>
-      <div className="mt-4">
-        {products.map((p, idx) => (
-          <div key={idx} className="mb-4 border p-2">
-            <img src={`data:image/jpeg;base64,${p.image}`} width={100} />
-            <select onChange={e => handleChange(p.cluster_id, e.target.value)}>
-              <option value="">Select label</option>
-              {masterData.map(m => (
-                <option key={m} value={m}>{m}</option>
-              ))}
-            </select>
-            <input
-              type="text"
-              placeholder="Custom label"
-              onBlur={e => handleChange(p.cluster_id, e.target.value)}
-            />
-          </div>
-        ))}
-      </div>
-      {products.length > 0 && (
-        <button onClick={handleSubmit}>Save Labels</button>
-      )}
+    <div style={{ position: 'relative', display: 'inline-block' }}>
+      <img src={`data:image/jpeg;base64,${image}`} ref={imgRef} alt="shelf" />
+      {detections.map((d, idx) => {
+        const [x1, y1, x2, y2] = d.bbox;
+        const color = colorMap[d.cluster_id] || colors[d.cluster_id % colors.length];
+        const left = scale(x1, width, dims.w);
+        const top = scale(y1, height, dims.h);
+        const boxW = scale(x2 - x1, width, dims.w);
+        const boxH = scale(y2 - y1, height, dims.h);
+        return (
+          <div
+            key={idx}
+            style={{
+              position: 'absolute',
+              left,
+              top,
+              width: boxW,
+              height: boxH,
+              border: `2px solid ${color}`,
+              boxSizing: 'border-box',
+            }}
+          />
+        );
+      })}
     </div>
   );
 }
 
-export default App;
+function ShareChart({ counts }) {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  return (
+    <div>
+      {Object.entries(counts).map(([label, count]) => {
+        const pct = total ? (count / total) * 100 : 0;
+        return (
+          <div key={label} style={{ margin: '4px 0' }}>
+            <div style={{ fontSize: '0.9em' }}>{label} - {pct.toFixed(1)}%</div>
+            <div style={{ background: '#ddd', height: '10px', position: 'relative' }}>
+              <div style={{ width: `${pct}%`, background: '#69c', height: '10px' }} />
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function App() {
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState(null);
+  const [image, setImage] = useState(null);
+  const [detections, setDetections] = useState([]);
+  const [clusters, setClusters] = useState([]);
+  const [imgWidth, setImgWidth] = useState(1);
+  const [imgHeight, setImgHeight] = useState(1);
+  const [clusterCount, setClusterCount] = useState(10);
+  const [labels, setLabels] = useState({});
+
+  const colorMap = colors;
+
+  const uploadAndCluster = async (n) => {
+    if (!file) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    try {
+      const res = await axios.post(`/upload-image?clusters=${n}`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      setImage(res.data.image);
+      setImgWidth(res.data.width);
+      setImgHeight(res.data.height);
+      setDetections(res.data.detections);
+      setClusters(res.data.clusters);
+    } catch (err) {
+      log('upload failed ' + err);
+    }
+  };
+
+  const handleNext1 = () => {
+    if (!file) return;
+    setStep(2);
+    uploadAndCluster(clusterCount);
+  };
+
+  const handleClusterSlider = (e) => {
+    const n = parseInt(e.target.value, 10);
+    setClusterCount(n);
+    uploadAndCluster(n);
+  };
+
+  const handleLabel = (cid, value) => {
+    setLabels(prev => ({ ...prev, [cid]: value }));
+  };
+
+  const handleSave = async () => {
+    await axios.post('/save-labels', labels);
+    setStep(3);
+  };
+
+  const shareCounts = () => {
+    const counts = {};
+    detections.forEach(d => {
+      const label = labels[d.cluster_id];
+      if (!label) return;
+      counts[label] = (counts[label] || 0) + 1;
+    });
+    return counts;
+  };
+
+  return (
+    <div style={{ padding: '20px', fontFamily: 'sans-serif' }}>
+      <div style={{ marginBottom: '20px', fontWeight: 'bold' }}>
+        {[1,2,3].map(n => (
+          <span key={n} style={{ color: step === n ? '#007bff' : '#000' }}>
+            {n}
+            {n < 3 && ' > '}
+          </span>
+        ))}
+      </div>
+
+      {step === 1 && (
+        <div>
+          <input type="file" onChange={e => setFile(e.target.files[0])} />
+          <div style={{ marginTop: '20px' }}>
+            <button onClick={handleNext1}>Next</button>
+          </div>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div>
+          {image && (
+            <div>
+              <BoxOverlay image={image} detections={detections} width={imgWidth} height={imgHeight} colorMap={colorMap} />
+            </div>
+          )}
+          <div style={{ margin: '20px 0' }}>
+            Clusters: {clusterCount}
+            <input type="range" min="2" max="20" value={clusterCount} onChange={handleClusterSlider} />
+          </div>
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {clusters.map(c => (
+              <div key={c.cluster_id} style={{ margin: '10px', textAlign: 'center' }}>
+                <img src={`data:image/jpeg;base64,${c.image}`} width={80} />
+                <select onChange={e => handleLabel(c.cluster_id, e.target.value)} value={labels[c.cluster_id] || ''}>
+                  <option value="">Label</option>
+                  {masterData.map(m => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+              </div>
+            ))}
+          </div>
+          <button onClick={handleSave}>Save Labels</button>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div>
+          {image && (
+            <BoxOverlay
+              image={image}
+              detections={detections}
+              width={imgWidth}
+              height={imgHeight}
+              colorMap={(function() {
+                const labelColors = {};
+                Object.values(labels).forEach((lab, i) => {
+                  if (!labelColors[lab]) {
+                    labelColors[lab] = colors[i % colors.length];
+                  }
+                });
+                const map = {};
+                Object.entries(labels).forEach(([cid, lab]) => {
+                  map[cid] = labelColors[lab];
+                });
+                return map;
+              })()}
+            />
+          )}
+          <h3>Share of facings</h3>
+          <ShareChart counts={shareCounts()} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,12 @@ conda activate facings-identifier
 pip install --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 ```
 
+**Ensure NumPy < 2 is installed**
+
+``` Bash
+pip install "numpy<2"
+```
+
 **Identifying crops from a shelf image**
 
 Assuming the image you want to analyze is located at data/img/testing.jpg, you can use the following command to identify the different product facings and predict their corresponding product names:
@@ -169,6 +175,8 @@ uvicorn backend.main:app --reload
 
 The API exposes `/upload-image`, `/save-labels`, `/clusters`, and `/log` endpoints on `http://localhost:8000`.
 
+When the frontend interacts with these endpoints, the backend prints informative log messages in the terminal.
+
 **Start the frontend**
 
 ```bash
@@ -177,7 +185,13 @@ npm install
 npm run dev
 ```
 
-Open `http://localhost:3000` and upload a shelf image. After detection and clustering, select a label for each cluster and click *Save Labels*.
+Open `http://localhost:3000` to access the three-step interface:
+
+1. **Upload** a shelf photo.
+2. **Adjust clustering** with the slider and label the representative images.
+3. View the color coded result and *share of facings* chart.
+
+Click *Save Labels* to store the selections.
 
 
 ## Conclusions

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ mkl_fft==1.3.8
 mkl_random==1.2.4
 mpmath==1.3.0
 networkx==3.5
-numpy==1.25.4
+numpy<2
 opencv-python==4.11.0.86
 packaging==25.0
 pandas==2.3.0

--- a/src/product_clusterer.py
+++ b/src/product_clusterer.py
@@ -2,7 +2,7 @@ from typing import List, Dict, DefaultDict
 from collections import defaultdict
 import math
 import numpy as np
-from sklearn.cluster import KMeans
+from sklearn.cluster import AgglomerativeClustering
 
 from .img2vec_resnet18 import Img2VecResnet18
 
@@ -13,8 +13,8 @@ class ProductClusterer:
         self.img2vec = Img2VecResnet18()
         self.n_clusters = n_clusters
 
-    def cluster(self, items: List[Dict]) -> Dict[int, List[Dict]]:
-        """Return a mapping of cluster id to items with embeddings."""
+    def cluster(self, items: List[Dict], n_clusters: int | None = None) -> Dict[int, Dict]:
+        """Return a mapping of cluster id to items with embeddings and representative index."""
         embeddings = []
         for item in items:
             vec = self.img2vec.getVec(item["image"])
@@ -25,11 +25,20 @@ class ProductClusterer:
             return {}
 
         embeddings_arr = np.array(embeddings)
-        n_clusters = self.n_clusters or max(1, int(math.sqrt(len(embeddings))))
-        kmeans = KMeans(n_clusters=n_clusters, random_state=0, n_init=10)
-        labels = kmeans.fit_predict(embeddings_arr)
+        n_clusters = n_clusters or self.n_clusters or max(1, int(math.sqrt(len(embeddings))))
+        clustering = AgglomerativeClustering(n_clusters=n_clusters)
+        labels = clustering.fit_predict(embeddings_arr)
 
-        clusters: DefaultDict[int, List[Dict]] = defaultdict(list)
+        groups: DefaultDict[int, List[Dict]] = defaultdict(list)
         for label, item in zip(labels, items):
-            clusters[int(label)].append(item)
+            groups[int(label)].append(item)
+
+        clusters: Dict[int, Dict] = {}
+        for cid, cluster_items in groups.items():
+            arr = np.array([i["embedding"] for i in cluster_items])
+            center = arr.mean(axis=0)
+            dists = np.linalg.norm(arr - center, axis=1)
+            rep_idx = int(dists.argmin())
+            clusters[cid] = {"items": cluster_items, "representative_index": rep_idx}
+
         return clusters


### PR DESCRIPTION
## Summary
- implement hierarchical clustering and expose representative images
- return bounding boxes and original image info from backend
- revamp frontend with 3-step workflow and slider to tweak clusters
- display share-of-facings chart
- document new interface in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68446a44e6dc8324872fa9ce240a77f6